### PR TITLE
fixed param name in analyze_consensus_threshold

### DIFF
--- a/examples/sample_mode_multi.ipynb
+++ b/examples/sample_mode_multi.ipynb
@@ -807,8 +807,8 @@
       "source": [
         "# look at the number and proportion of nodes in common across the rewired networks\n",
         "cons_stats = splitpea.analyze_consensus_threshold(\n",
-        "    neg_path='consensus_network_neg.pickle',\n",
-        "    pos_path='consensus_network_pos.pickle',\n",
+        "    neg_consensus='consensus_network_neg.pickle',\n",
+        "    pos_consensus='consensus_network_pos.pickle',\n",
         "    save_pdf_prefix='ucs_consensus_sum'\n",
         ")\n",
         "cons_stats"


### PR DESCRIPTION
In the tutorial notebook, we had the wrong param name when calling analyze_consensus_threshold. That is fixed here.  